### PR TITLE
fix: screenName @ injection pattern

### DIFF
--- a/src/main/java/jp/gecko655/bot/fujimiya/FujimiyaReply.java
+++ b/src/main/java/jp/gecko655/bot/fujimiya/FujimiyaReply.java
@@ -88,7 +88,7 @@ public class FujimiyaReply extends AbstractCron {
 
     private void followBack(Status reply) throws TwitterException {
         String userName = reply.getUser().getName();
-        if (Pattern.matches("@[_A-Za-z]", userName)){
+        if (Pattern.compile("@[_A-Za-z]").matcher(userName).find()) {
             StatusUpdate update = new StatusUpdate("@" + reply.getUser().getScreenName() + " その名前やめろ");
             update.setInReplyToStatusId(reply.getId());
             twitter.updateStatus(update);


### PR DESCRIPTION
`Pattern.matches("@[_A-Za-z]", userName)` is true if only length of the userName that starts with "@" is 2.
To avoid unexpected mentions, you may use `Matcher#find`.